### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,23 @@ This service can be used with any project type. The examples below are Drupal-sp
 
 ## Install/Update
 
-1. `ddev get ddev/ddev-selenium-standalone-firefox`
-2. Optional. Update the provided .ddev/config.selenium-standalone-firefox.yaml as you see fit(and remove the #ddev-generated line). You can also just override lines in your .ddev/config.yaml
-3. Optional. Check config.selenium-standalone-firefox.yaml and docker-compose.selenium-firefox.yaml into your source control.
-4. Update by re-running `ddev get ddev/ddev-selenium-standalone-firefox`.
+For DDEV v1.23.5 or above run
+
+```sh
+ddev add-on get ddev/ddev-selenium-standalone-firefox
+```
+
+For earlier versions of DDEV run
+
+```sh
+ddev get ddev/ddev-selenium-standalone-firefox
+```
+
+### Optional steps
+
+1. Optional. Update the provided .ddev/config.selenium-standalone-firefox.yaml as you see fit(and remove the #ddev-generated line). You can also just override lines in your .ddev/config.yaml
+1. Optional. Check config.selenium-standalone-firefox.yaml and docker-compose.selenium-firefox.yaml into your source control.
+1. Update by re-running `ddev add-on get ddev/ddev-selenium-standalone-firefox`.
 
 ## Use
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.